### PR TITLE
ci: Explicitly use schemathesis 3.39.6 instead of stable [sc-122824]

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -20,8 +20,10 @@ fi
 docker run --pull=always --rm -v "$SPEC_DIR/":/spec:ro redocly/openapi-cli lint /spec/open-api.yml
 
 # Schema validation against the cloud image
+# TODO(rhall): revert back to the stable label once we remove the --stateful flag
+# which no longer works with v4. go/sc/122824
 docker run --pull=always --rm --network=host -v "$SPEC_DIR/":/spec:ro \
-    schemathesis/schemathesis:stable run \
+    schemathesis/schemathesis:3.39.6 run \
         --base-url="$CLOUD_URL" \
         --checks all \
         --exclude-checks status_code_conformance \


### PR DESCRIPTION
stable was recently changed to use [v4.0.0a1](https://github.com/schemathesis/schemathesis/releases/tag/v4.0.0a1), which removed our usage of
the --stateful flag. For now let's just revert back to the latest v3
tag to unblock calyptia-backend tests.

Example failure: https://github.com/chronosphereio/calyptia-api/actions/runs/12801963028/job/35692291960#step:5:1660