### PR TITLE
Revert "chore: Disable response_schema_conformance check for schema tests [sc-134006] (#317)"

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -20,14 +20,11 @@ fi
 docker run --pull=always --rm -v "$SPEC_DIR/":/spec:ro redocly/openapi-cli lint /spec/open-api.yml
 
 # Schema validation against the cloud image
-# TODO(rhall): revert back to the stable label once we remove the --stateful flag
-# which no longer works with v4. go/sc/122824
-# TODO(rhall): response_schema_conformance is excluded due to go/sc/134006
 docker run --pull=always --rm --network=host -v "$SPEC_DIR/":/spec:ro \
-    schemathesis/schemathesis:3.39.6 run \
+    schemathesis/schemathesis:3.39.16 run \
         --base-url="$CLOUD_URL" \
         --checks all \
-        --exclude-checks status_code_conformance,response_schema_conformance \
+        --exclude-checks status_code_conformance \
         --header "X-Project-Token: $TOKEN" \
         --stateful=links \
         --exclude-operation-id awsCustomerRedirect \

--- a/spec/open-api.yml
+++ b/spec/open-api.yml
@@ -502,7 +502,7 @@ components:
         configFormat:
           type: string
           enum:
-            - ini
+            - classic
             - json
             - yaml
         tags:
@@ -608,7 +608,7 @@ components:
         configFormat:
           type: string
           enum:
-            - ini
+            - classic
             - json
             - yaml
           nullable: true
@@ -658,7 +658,7 @@ components:
         configFormat:
           type: string
           enum:
-            - ini
+            - classic
             - json
             - yaml
           nullable: true
@@ -1768,10 +1768,8 @@ components:
         - updatedAt
         - minReplicas
         - maxReplicas
-        - scaleUpType
         - scaleUpValue
         - scaleUpPeriodSeconds
-        - scaleDownType
         - scaleDownValue
         - scaleDownPeriodSeconds
         - utilizationCPUAverage
@@ -1809,7 +1807,7 @@ components:
         configFormat:
           type: string
           enum:
-            - ini
+            - classic
             - json
             - yaml
         createdAt:
@@ -1841,6 +1839,7 @@ components:
             - CHECKS_FAILED
         events:
           type: array
+          nullable: true
           items:
             $ref: "#/components/schemas/PipelineEvent"
         createdAt:
@@ -3316,7 +3315,7 @@ components:
         configFormat:
           type: string
           enum:
-            - ini
+            - classic
             - json
             - yaml
           nullable: true
@@ -6964,7 +6963,7 @@ paths:
         - schema:
             type: string
             enum:
-              - ini
+              - classic
               - json
               - yaml
           in: query
@@ -7075,7 +7074,7 @@ paths:
           schema:
             type: string
             enum:
-              - ini
+              - classic
               - json
               - yaml
           in: query
@@ -7143,7 +7142,7 @@ paths:
         - schema:
             type: string
             enum:
-              - ini
+              - classic
               - json
               - yaml
           in: query
@@ -7208,7 +7207,7 @@ paths:
           schema:
             type: string
             enum:
-              - ini
+              - classic
               - json
               - yaml
           in: query
@@ -7258,7 +7257,7 @@ paths:
         - schema:
             type: string
             enum:
-              - ini
+              - classic
               - json
               - yaml
           in: query
@@ -7379,7 +7378,7 @@ paths:
         - schema:
             type: string
             enum:
-              - ini
+              - classic
               - json
               - yaml
           in: query
@@ -10126,7 +10125,7 @@ paths:
         - schema:
             type: string
             enum:
-              - ini
+              - classic
               - json
               - yaml
           in: query
@@ -10197,7 +10196,7 @@ paths:
         - schema:
             type: string
             enum:
-              - ini
+              - classic
               - json
               - yaml
           in: query
@@ -10290,7 +10289,7 @@ paths:
         - schema:
             type: string
             enum:
-              - ini
+              - classic
               - json
               - yaml
           in: query
@@ -10299,7 +10298,7 @@ paths:
         - schema:
             type: string
             enum:
-              - ini
+              - classic
               - json
               - yaml
           in: query


### PR DESCRIPTION
This reverts commit a467ef9a52f7e2deed7cad21c07ef35c7da1f8b6.

In addition, upgraded to the latest schemathesis and removed the TODO to upgrade to v4, which isn't even stable yet.